### PR TITLE
feat: solve problem02 with bisection; add Exercise 2 (a) & (b)

### DIFF
--- a/scripts/methods/nonlinear/bisection.py
+++ b/scripts/methods/nonlinear/bisection.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Callable, List, Tuple, Optional
+
+@dataclass
+class BisectionStep:
+    iteration_index: int
+    left_endpoint: float
+    right_endpoint: float
+    midpoint: float
+    function_value_at_midpoint: float
+    stopping_value: Optional[float]  # value used by the chosen stopping criterion
+
+@dataclass
+class BisectionResult:
+    """Result of the bisection method."""
+    root: float
+    iterations: int
+    converged: bool
+    final_interval: Tuple[float, float]
+    function_value_at_root: float
+    history: List[BisectionStep]
+
+def bisection(
+    function_to_solve: Callable[[float], float],
+    left_endpoint: float,
+    right_endpoint: float,
+    tolerance: float,
+    maximum_iterations: int = 10_000,
+    *,
+    stopping_criterion: str = "C",  # "B" -> |f(m)| < tol   |   "C" -> |m_k - m_{k-1}| < tol
+) -> BisectionResult:
+    """
+    Bisection method with selectable stopping criterion (B or C).
+
+    - Criterion B:  stop when |f(midpoint)| < tolerance
+    - Criterion C:  stop when |midpoint_k - midpoint_{k-1}| < tolerance  (absolute)
+
+    Preconditions (Bolzano): opposite signs at endpoints and continuity on [a,b].
+    """
+    stopping_criterion = stopping_criterion.upper()
+    if stopping_criterion not in {"B", "C"}:
+        raise ValueError("stopping_criterion must be 'B' or 'C'.")
+
+    function_value_left = function_to_solve(left_endpoint)
+    function_value_right = function_to_solve(right_endpoint)
+
+    if function_value_left == 0.0:
+        step0 = BisectionStep(0, left_endpoint, right_endpoint, left_endpoint, function_value_left, None)
+        return BisectionResult(left_endpoint, 0, True, (left_endpoint, right_endpoint), function_value_left, [step0])
+
+    if function_value_right == 0.0:
+        step0 = BisectionStep(0, left_endpoint, right_endpoint, right_endpoint, function_value_right, None)
+        return BisectionResult(right_endpoint, 0, True, (left_endpoint, right_endpoint), function_value_right, [step0])
+
+    if function_value_left * function_value_right > 0:
+        raise ValueError("Bisection requires opposite signs at the endpoints (Bolzano condition).")
+
+    history: List[BisectionStep] = []
+    previous_midpoint: Optional[float] = None
+
+    for iteration_index in range(1, maximum_iterations + 1):
+        midpoint = (left_endpoint + right_endpoint) / 2.0
+        function_value_midpoint = function_to_solve(midpoint)
+
+        # Update the bracket first so the returned final_interval matches the last decision
+        if function_value_left * function_value_midpoint > 0:
+            left_endpoint, function_value_left = midpoint, function_value_midpoint
+        else:
+            right_endpoint, function_value_right = midpoint, function_value_midpoint
+
+        # Compute the stopping value depending on the chosen criterion
+        if stopping_criterion == "B":
+            stopping_value = abs(function_value_midpoint)
+        else:  # "C"
+            stopping_value = None if previous_midpoint is None else abs(midpoint - previous_midpoint)
+
+        current_step = BisectionStep(
+            iteration_index=iteration_index,
+            left_endpoint=left_endpoint,
+            right_endpoint=right_endpoint,
+            midpoint=midpoint,
+            function_value_at_midpoint=function_value_midpoint,
+            stopping_value=stopping_value,
+        )
+        history.append(current_step)
+
+        # Check for convergence
+        if function_value_midpoint == 0.0:
+            return BisectionResult(midpoint, iteration_index, True, (left_endpoint, right_endpoint), function_value_midpoint, history)
+
+        if stopping_value is not None and stopping_value < tolerance:
+            return BisectionResult(midpoint, iteration_index, True, (left_endpoint, right_endpoint), function_value_midpoint, history)
+
+        previous_midpoint = midpoint
+
+    return BisectionResult(midpoint, iteration_index, False, (left_endpoint, right_endpoint), function_value_midpoint, history)

--- a/scripts/problems/problem01_iterative_linear.py
+++ b/scripts/problems/problem01_iterative_linear.py
@@ -25,19 +25,20 @@ def main() -> None:
     # initial guess (from the exercise)
     initial_guess = np.array([2.0, 1.0, 0.0], dtype=float)
 
+    tolerance = 1e-2
+
     # Solve using Gauss–Seidel with criterion C and tolerance 1e-2 (0.01)
     report = gauss_seidel(
         matrix=matrix,
         right_hand_side=right_hand_side,
         initial_guess=initial_guess,
-        tolerance=1e-2,
+        tolerance=tolerance,
         max_iterations=10_000,
         stopping_criterion="C",
     )
 
-    # Print a compact summary
-    # np.set_printoptions(formatter={'float_kind': "{:.1f}".format}) # type: ignore[arg-type]
-    print("Gauss–Seidel result for Problem 1 (exercise list) | Criterion C, ε=0.01:")
+    print()
+    print("Exercise 1 - Gauss-Seidel Method")
     print("Coefficient matrix (A):")
     print("A =\n", matrix)
     print()
@@ -46,6 +47,8 @@ def main() -> None:
     print()
     print("Initial guess:")
     print("x\u207D\u2070\u207E =", initial_guess)
+    print()
+    print(f"Stopping rule: Criterion C max[(|xi^(k) − xi^(k−1) / xi^(k)| < ε)] with ε = {tolerance:g}")
     print()
     for iteration, solution, absolute_error, relative_error, residual_inf in report.history:
         print(f"Iteration: {iteration}")

--- a/scripts/problems/problem02a_bisection.py
+++ b/scripts/problems/problem02a_bisection.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+import math
+from scripts.methods.nonlinear.bisection import bisection
+
+def function_to_solve(x: float) -> float:
+    return math.exp(x) - x**3 + 3.0
+
+def main() -> None:
+    left_endpoint, right_endpoint = 2.0, 3.0
+    tolerance = 1e-1  # epsilon = 0.1, stopping criterion C: |m^(k) - m^(k-1)| < epsilon
+
+    result = bisection(
+        function_to_solve,
+        left_endpoint,
+        right_endpoint,
+        tolerance=tolerance,
+        maximum_iterations=10_000,
+        stopping_criterion="C",
+    )
+
+    rounded_root = round(result.root, 3)
+    function_at_rounded = function_to_solve(rounded_root)
+
+    print()
+    print("Exercise 2(a) — Bisection Method")
+    print("Function: f(x) = e^x − x^3 + 3")
+    print(f"Initial interval: [{left_endpoint:.3f}, {right_endpoint:.3f}]")
+    print(f"Stopping rule: Criterion C (|m^(k) − m^(k−1)| < ε) with ε = {tolerance:g}")
+    print("Final answer must be rounded to 3 decimal places.\n")
+
+    header = (
+        f"{'iteration':>9} | "
+        f"{'left_endpoint':>14} | "
+        f"{'right_endpoint':>14} | "
+        f"{'midpoint':>14} | "
+        f"{'f(midpoint)':>14} | "
+        f"{'abs_error':>14}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for step in result.history:
+        abs_err = "—" if step.stopping_value is None else f"{step.stopping_value:.6f}"
+        print(
+            f"{step.iteration_index:9d} | "
+            f"{step.left_endpoint:14.6f} | "
+            f"{step.right_endpoint:14.6f} | "
+            f"{step.midpoint:14.6f} | "
+            f"{step.function_value_at_midpoint:14.6f} | "
+            f"{abs_err:>14}"
+        )
+
+    print()
+    print(f"Converged: {result.converged} in {result.iterations} iterations")
+    print(f"x* (3 decimal places) ≈ {rounded_root:.3f}   f(x* rounded) ≈ {function_at_rounded:.6f}")
+    print(f"Final interval: [{result.final_interval[0]:.6f}, {result.final_interval[1]:.6f}]\n")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/problems/problem02b_bisection.py
+++ b/scripts/problems/problem02b_bisection.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import math
+from scripts.methods.nonlinear.bisection import bisection
+
+def function_to_solve(x: float) -> float:
+    return math.sin(x) - 1.0 / (x * x)
+
+def main() -> None:
+    left_endpoint, right_endpoint = 1.0, 1.4
+    tolerance = 2e-2  # epsilon = 0.02, stopping criterion B: |g(m)| < epsilon
+
+    result = bisection(
+        function_to_solve,
+        left_endpoint,
+        right_endpoint,
+        tolerance=tolerance,
+        maximum_iterations=10_000,
+        stopping_criterion="B",
+    )
+
+    rounded_root = round(result.root, 3)
+    function_at_rounded = function_to_solve(rounded_root)
+
+    print()
+    print("Exercise 2(b) — Bisection Method")
+    print("Function: g(x) = sin(x) − 1/x^2")
+    print(f"Initial interval: [{left_endpoint:.3f}, {right_endpoint:.3f}]")
+    print(f"Stopping rule: Criterion B (|g(m)| < ε) with ε = {tolerance:g}")
+    print("Final answer must be rounded to 3 decimal places.\n")
+
+    header = (
+        f"{'iteration':>9} | "
+        f"{'left_endpoint':>14} | "
+        f"{'right_endpoint':>14} | "
+        f"{'midpoint':>14} | "
+        f"{'g(midpoint)':>14} | "
+        f"{'criterion_B':>14}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for step in result.history:
+        crit_text = "—" if step.stopping_value is None else f"{step.stopping_value:.6f}"
+        print(
+            f"{step.iteration_index:9d} | "
+            f"{step.left_endpoint:14.6f} | "
+            f"{step.right_endpoint:14.6f} | "
+            f"{step.midpoint:14.6f} | "
+            f"{step.function_value_at_midpoint:14.6f} | "
+            f"{crit_text:>14}"
+        )
+
+    print()
+    print(f"Converged: {result.converged} in {result.iterations} iterations")
+    print(f"x* (3 decimal places) ≈ {rounded_root:.3f}   f(x* rounded) ≈ {function_at_rounded:.6f}")
+    print(f"Final interval: [{result.final_interval[0]:.6f}, {result.final_interval[1]:.6f}]\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement scalar bisection with selectable stopping criterion (B or C), per-iteration history, and caller-provided tolerance.

Add problems/p02_bisection.py (Ex. 2a — Criterion C, ε=0.10) and problems/p02_bisection_b.py (Ex. 2b — Criterion B, ε=0.02).