### PR TITLE
feat: add Newton–Raphson and Problem 3 solver

### DIFF
--- a/scripts/methods/nonlinear/newton.py
+++ b/scripts/methods/nonlinear/newton.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Callable, List, Literal
+
+
+StoppingCriterion = Literal["B", "C"]
+
+
+@dataclass
+class NewtonStep:
+    iteration: int
+    current_estimate: float
+    function_value: float
+    derivative_value: float
+    update_step: float
+    stopping_value: float
+
+
+@dataclass
+class NewtonResult:
+    converged: bool
+    iterations: int
+    root_estimate: float
+    final_stopping_value: float
+    history: List[NewtonStep] = field(default_factory=list)
+
+
+def newton_method(
+    function: Callable[[float], float],
+    derivative: Callable[[float], float],
+    initial_guess: float,
+    tolerance: float,
+    stopping: StoppingCriterion,
+    maximum_iterations: int,
+) -> NewtonResult:
+    """
+    Run the Newton–Raphson method.
+
+    Parameters
+    ----------
+    function : Callable[[float], float]
+        Nonlinear function f(x).
+    derivative : Callable[[float], float]
+        Derivative f'(x).
+    initial_guess : float
+        Starting point x_0.
+    tolerance : float
+        Epsilon used in the chosen stopping criterion.
+    stopping : {"B", "C"}
+        "B": stop when |f(x_{k+1})| < epsilon
+        "C": stop when |x_{k+1} - x_k| < epsilon  (absolute)
+    maximum_iterations : int
+        Safety cap on the number of iterations.
+
+    Returns
+    -------
+    NewtonResult
+        Convergence flag, iteration count, final estimate, and detailed history.
+    """
+    x_current = initial_guess
+    history: List[NewtonStep] = []
+
+    for iteration in range(1, maximum_iterations + 1):
+        f_value = function(x_current)
+        derivative_value = derivative(x_current)
+
+        if derivative_value == 0.0:
+            # Cannot proceed if the tangent is horizontal at the current point.
+            return NewtonResult(
+                converged=False,
+                iterations=iteration - 1,
+                root_estimate=x_current,
+                final_stopping_value=float("inf"),
+                history=history,
+            )
+
+        x_next = x_current - f_value / derivative_value
+        update_step = x_next - x_current
+
+        # Stopping value according to the chosen criterion.
+        if stopping == "C":
+            stopping_value = abs(update_step)
+        else:  # stopping == "B"
+            stopping_value = abs(function(x_next))
+
+        history.append(
+            NewtonStep(
+                iteration=iteration,
+                current_estimate=x_current,
+                function_value=f_value,
+                derivative_value=derivative_value,
+                update_step=update_step,
+                stopping_value=stopping_value,
+            )
+        )
+
+        x_current = x_next
+
+        if stopping_value < tolerance:
+            return NewtonResult(
+                converged=True,
+                iterations=iteration,
+                root_estimate=x_current,
+                final_stopping_value=stopping_value,
+                history=history,
+            )
+
+    # If we reach here, maximum_iterations was hit.
+    return NewtonResult(
+        converged=False,
+        iterations=maximum_iterations,
+        root_estimate=x_current,
+        final_stopping_value=history[-1].stopping_value if history else float("inf"),
+        history=history,
+    )

--- a/scripts/problems/problem03_newton_exponential.py
+++ b/scripts/problems/problem03_newton_exponential.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+import math
+from scripts.methods.nonlinear.newton import newton_method, NewtonResult
+
+# Problem constants (from the exercise)
+kA = 0.0866434
+kB = 0.346574
+initial_guess_t = 9.0
+tolerance = 0.002
+maximum_iterations = 10_000
+
+
+def function(t: float) -> float:
+    """f(t) = e^{-kA t} - e^{-kB t} - 0.3"""
+    return math.exp(-kA * t) - math.exp(-kB * t) - 0.3
+
+
+def derivative(t: float) -> float:
+    """f'(t) = -kA e^{-kA t} + kB e^{-kB t}"""
+    return -kA * math.exp(-kA * t) + kB * math.exp(-kB * t)
+
+
+def print_header() -> None:
+    print()
+    print("Exercise 3 - Newton-Rapshon Method")
+    print("Function: f(t) = exp(-kA*t) - exp(-kB*t) - 0.3")
+    print(f"Parameters: kA = {kA}, kB = {kB}")
+    print(f"Initial guess: t0 = {initial_guess_t}")
+    print(f"Stopping criterion: C (absolute) with epsilon = {tolerance}")
+    print("Report final answer with 3 decimals.\n")
+
+
+def print_table(result: NewtonResult) -> None:
+    print("iteration |         t_k |           f(t_k) |          f'(t_k) |        delta_t |      abs_error")
+    print("-----------------------------------------------------------------------------------------------")
+    for step in result.history:
+        print(
+            f"{step.iteration:9d} | "
+            f"{step.current_estimate:12.6f} | "
+            f"{step.function_value:15.6f} | "
+            f"{step.derivative_value:15.6f} | "
+            f"{step.update_step:13.6f} | "
+            f"{step.stopping_value:13.6f}"
+        )
+
+
+def main() -> None:
+    print_header()
+
+    result = newton_method(
+        function=function,
+        derivative=derivative,
+        initial_guess=initial_guess_t,
+        tolerance=tolerance,
+        stopping="C",
+        maximum_iterations=maximum_iterations,
+    )
+
+    # Summary (final values rounded to 3 decimals as required)
+    estimated_t = result.root_estimate
+    rounded_estimated_t = round(estimated_t, 3)
+    residual_at_rounded = function(rounded_estimated_t)
+
+    print("\nConverged:", result.converged)
+    print("Iterations:", result.iterations)
+    print(f"t* ≈ {rounded_estimated_t:.3f}   f(t*) evaluated at rounded t*: {residual_at_rounded:.6f}\n")
+
+    print_table(result)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement generic Newton–Raphson (scripts/methods/nonlinear/newton.py) with dataclasses and stopping criteria B and C.

Log per-iteration data: iteration, x_k, f(x_k), f’(x_k), Δx, stopping_value.

Add problem runner problems/p03_newton_decay_difference.py (kA=0.0866434, kB=0.346574, t0=9, ε=0.002, criterion C).

Print header + iteration table; final result rounded to 3 decimals.

No problem-specific defaults inside the method; derivative-zero guard.