### PR TITLE
feat: add secant method (criterion B) and solve problem p04

### DIFF
--- a/scripts/methods/nonlinear/secant.py
+++ b/scripts/methods/nonlinear/secant.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Callable, List, Literal
+
+
+StoppingCriterion = Literal["B", "C"]
+
+
+@dataclass
+class SecantStep:
+    iteration: int
+    previous_estimate: float          # x_{k-1}
+    current_estimate: float           # x_k
+    next_estimate: float              # x_{k+1}
+    function_value_at_next: float     # f(x_{k+1})
+    stopping_value: float             # |f(x_{k+1})| (B) or |x_{k+1} - x_k| (C)
+
+
+@dataclass
+class SecantResult:
+    converged: bool
+    iterations: int
+    root_approximation: float
+    function_value_at_root: float
+    history: List[SecantStep] = field(default_factory=list)
+    final_pair: tuple[float, float] | None = None  # (x_{k-1}, x_k) at return
+
+
+def secant(
+    function: Callable[[float], float],
+    initial_x0: float,
+    initial_x1: float,
+    tolerance: float,
+    max_iterations: int,
+    stopping_criterion: StoppingCriterion,
+) -> SecantResult:
+    if initial_x0 == initial_x1:
+        raise ValueError("Secant requires distinct initial guesses: x(0) != x(1).")
+
+    history: List[SecantStep] = []
+
+    previous_estimate = float(initial_x0)  # x_{k-1}
+    current_estimate  = float(initial_x1)  # x_k
+    f_prev = function(previous_estimate)
+    f_curr = function(current_estimate)
+
+    # Safety pre-check on the current available iterate
+    if stopping_criterion == "B" and abs(f_curr) < tolerance:
+        return SecantResult(
+            converged=True,
+            iterations=0,
+            root_approximation=current_estimate,
+            function_value_at_root=f_curr,
+            history=history,
+            final_pair=(previous_estimate, current_estimate),
+        )
+    if stopping_criterion == "C" and abs(current_estimate - previous_estimate) < tolerance:
+        return SecantResult(
+            converged=True,
+            iterations=0,
+            root_approximation=current_estimate,
+            function_value_at_root=f_curr,
+            history=history,
+            final_pair=(previous_estimate, current_estimate),
+        )
+
+    for iteration in range(1, max_iterations + 1):
+        denominator = f_curr - f_prev
+        if denominator == 0.0:
+            # Cannot proceed. If we got here, pre-check above already ruled out convergence.
+            return SecantResult(
+                converged=False,
+                iterations=iteration - 1,
+                root_approximation=current_estimate,
+                function_value_at_root=f_curr,
+                history=history,
+                final_pair=(previous_estimate, current_estimate),
+            )
+
+        # Secant update
+        next_estimate = current_estimate - f_curr * (current_estimate - previous_estimate) / denominator
+        f_next = function(next_estimate)
+
+        # Stopping value recorded for this iteration (the exact criterion used)
+        if stopping_criterion == "B":
+            stopping_value = abs(f_next)
+        else:  # "C"
+            stopping_value = abs(next_estimate - current_estimate)
+
+        history.append(
+            SecantStep(
+                iteration=iteration,
+                previous_estimate=previous_estimate,
+                current_estimate=current_estimate,
+                next_estimate=next_estimate,
+                function_value_at_next=f_next,
+                stopping_value=stopping_value,
+            )
+        )
+
+        # Shift window to the newest two iterates
+        previous_estimate, f_prev = current_estimate, f_curr
+        current_estimate,  f_curr = next_estimate,  f_next
+
+        # Standard post-update stopping check on the "latest" x_k
+        if (stopping_criterion == "B" and abs(f_curr) < tolerance) or \
+           (stopping_criterion == "C" and abs(current_estimate - previous_estimate) < tolerance):
+            return SecantResult(
+                converged=True,
+                iterations=iteration,
+                root_approximation=current_estimate,
+                function_value_at_root=f_curr,
+                history=history,
+                final_pair=(previous_estimate, current_estimate),
+            )
+
+    # Reached iteration cap
+    return SecantResult(
+        converged=False,
+        iterations=max_iterations,
+        root_approximation=current_estimate,
+        function_value_at_root=f_curr,
+        history=history,
+        final_pair=(previous_estimate, current_estimate),
+    )

--- a/scripts/problems/problem04_secant.py
+++ b/scripts/problems/problem04_secant.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+import math
+from scripts.methods.nonlinear.secant import secant
+
+
+def function_to_solve(x: float) -> float:
+    return x * math.exp(x) - 1.0
+
+
+def main() -> None:
+    # Problem-specific configuration (explicit):
+    initial_x0 = 0.0
+    initial_x1 = 1.0
+    tolerance = 0.002
+    stopping_criterion = "B"  # |f(x_k)| < ε
+    max_iterations = 100
+
+    # Header:
+    print("Secant Method — Criterion B (|f(x_k)| < ε)")
+    print("Function: f(x) = x*e^x - 1")
+    print(f"Initial points: x(0) = {initial_x0:.3f}, x(1) = {initial_x1:.3f}")
+    print(f"ε = {tolerance}")
+    print("Final result must be rounded to 3 decimals.\n")
+
+    # Run:
+    result = secant(
+        function=function_to_solve,
+        initial_x0=initial_x0,
+        initial_x1=initial_x1,
+        tolerance=tolerance,
+        max_iterations=max_iterations,
+        stopping_criterion=stopping_criterion,
+    )
+
+    # Final report (evaluate f at the rounded x* as required):
+    x_star_rounded = round(result.root_approximation, 3)
+    f_at_rounded = function_to_solve(x_star_rounded)
+
+    print(f"Converged: {result.converged}")
+    print(f"iterations: {result.iterations}")
+    print(f"x* ≈ {x_star_rounded:.3f}   f(x*) ≈ {f_at_rounded:.6f}")
+
+    if result.final_pair is not None:
+        a, b = result.final_pair
+        print(f"Final pair: [{a:.3f}, {b:.3f}]")
+    print()
+
+    # Iteration table:
+    header = (
+        "iteration |   x_{k-1} (prev) |      x_k (curr) |     x_{k+1} (next) |    f(x_{k+1}) |   |f(x_{k+1})|"
+    )
+    print(header)
+    print("-" * len(header))
+    for step in result.history:
+        print(
+            f"{step.iteration:9d} | "
+            f"{step.previous_estimate:16.6f} | "
+            f"{step.current_estimate:16.6f} | "
+            f"{step.next_estimate:16.6f} | "
+            f"{step.function_value_at_next:13.6f} | "
+            f"{step.stopping_value:13.6f}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement scripts/methods/nonlinear/secant.py with dataclasses and full iteration log (prev, curr, next, f(next), stopping_value).

Supports criteria B (|f(x_k)| < ε) and C (|Δx| < ε); safety pre-check on current iterate and standard post-update check.

Add problems/p04_secant.py for f(x)=xe^x−1 with x(0)=0, x(1)=1, ε=0.002, criterion B, printing header/result/table per project spec and rounding final x to 3 decimals (evaluate f at rounded x*).