### PR TITLE
feat: add problem 6a–6c using Newton nonlinear systems method

### DIFF
--- a/scripts/methods/nonlinear/newton_systems.py
+++ b/scripts/methods/nonlinear/newton_systems.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Callable, List, Literal
+import numpy as np
+
+
+@dataclass
+class NewtonSystemStep:
+    iteration: int
+    current_estimate: np.ndarray
+    function_value: np.ndarray
+    stopping_value: float
+
+
+@dataclass
+class NewtonSystemResult:
+    converged: bool
+    iterations: int
+    approximate_solution: np.ndarray
+    function_at_solution: np.ndarray
+    history: List[NewtonSystemStep]
+
+
+def newton_system(
+    function: Callable[[np.ndarray], np.ndarray],
+    jacobian: Callable[[np.ndarray], np.ndarray],
+    initial_guess: np.ndarray,
+    tolerance: float,
+    max_iterations: int,
+    stopping_criterion: Literal["C", "B"] = "C",
+) -> NewtonSystemResult:
+    """
+    Perform Newton's method for SEANL.
+
+    Parameters
+    ----------
+    function : Callable
+        Maps x (ℝ^n) to F(x) (ℝ^n).
+    jacobian : Callable
+        Maps x (ℝ^n) to J(x) (n×n).
+    initial_guess : np.ndarray
+        Starting vector x^{0}.
+    tolerance : float
+        Tolerance ε (not hard-coded; must be provided by the problem).
+    max_iterations : int
+        Maximum number of Newton iterations.
+    stopping_criterion : {"C", "B"}
+        "C": stop when max_i |Δx_i| < ε;
+        "B": stop when max_i |F_i(x_k)| < ε.
+
+    Returns
+    -------
+    NewtonSystemResult
+        Convergence flag, number of iterations performed, last approximation,
+        F evaluated at the last approximation, and the full iteration history.
+    """
+    x_current = np.array(initial_guess, dtype=float)
+    history: List[NewtonSystemStep] = []
+
+    for k in range(1, max_iterations + 1):
+        F_val = function(x_current)
+        J_val = jacobian(x_current)
+
+        # Solve J(x_k) * v_k = -F(x_k)
+        try:
+            step_direction = np.linalg.solve(J_val, -F_val)
+        except np.linalg.LinAlgError as exc:
+            # Singular Jacobian or ill-conditioned solve -> fail fast
+            history.append(
+                NewtonSystemStep(
+                    iteration=k,
+                    current_estimate=x_current.copy(),
+                    function_value=F_val.copy(),
+                    stopping_value=np.inf,
+                )
+            )
+            return NewtonSystemResult(
+                converged=False,
+                iterations=k,
+                approximate_solution=x_current,
+                function_at_solution=F_val,
+                history=history,
+            )
+
+        x_next = x_current + step_direction
+
+        # Compute stopping value according to the selected criterion.
+        if stopping_criterion == "C":
+            stopping_value = float(np.max(np.abs(step_direction)))
+        elif stopping_criterion == "B":
+            stopping_value = float(np.max(np.abs(function(x_next))))
+        else:
+            raise ValueError("Unsupported stopping_criterion. Use 'C' or 'B'.")
+
+        # Log AFTER computing x^{k+1} and the stopping metric of this iteration.
+        history.append(
+            NewtonSystemStep(
+                iteration=k,
+                current_estimate=x_next.copy(),
+                function_value=function(x_next).copy(),
+                stopping_value=stopping_value,
+            )
+        )
+
+        # Check stopping condition.
+        if stopping_value < tolerance:
+            return NewtonSystemResult(
+                converged=True,
+                iterations=k,
+                approximate_solution=x_next,
+                function_at_solution=function(x_next),
+                history=history,
+            )
+
+        x_current = x_next
+
+    # Did not satisfy tolerance within max_iterations
+    return NewtonSystemResult(
+        converged=False,
+        iterations=max_iterations,
+        approximate_solution=x_current,
+        function_at_solution=function(x_current),
+        history=history,
+    )

--- a/scripts/problems/problem06a_nonlinear_systems.py
+++ b/scripts/problems/problem06a_nonlinear_systems.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+import numpy as np
+from scripts.methods.nonlinear.newton_systems import newton_system
+
+
+def function(vector: np.ndarray) -> np.ndarray:
+    """F(x) for the given SEANL."""
+    x1, x2 = vector
+    f1 = x2 - (x1**2 - 4.0 * x1 + 3.0)
+    f2 = x1**2 + x2**2 - 15.0
+    return np.array([f1, f2], dtype=float)
+
+
+def jacobian(vector: np.ndarray) -> np.ndarray:
+    """Jacobian J(x) for the given SEANL."""
+    x1, x2 = vector
+    j11 = -2.0 * x1 + 4.0
+    j12 = 1.0
+    j21 = 2.0 * x1
+    j22 = 2.0 * x2
+    return np.array([[j11, j12], [j21, j22]], dtype=float)
+
+
+def print_header(epsilon: float, max_iterations: int, initial_guess: np.ndarray) -> None:
+    """Minimal header required by the project."""
+    print("=== Newton method for SEANL (Exercise 6a) ===")
+    print("f1(x1, x2) = x2 - (x1**2 - 4*x1 + 3)")
+    print("f2(x1, x2) = x1**2 + x2**2 - 15")
+    print(f"Initial guess x(0) = [{initial_guess[0]:.3f}, {initial_guess[1]:.3f}]")
+    print("Stopping: Criterion C (absolute), ε =", f"{epsilon:.3f}")
+    print(f"Max iterations: {max_iterations}")
+    print("Round final x* to 3 decimals; evaluate F at the rounded x*.\n")
+
+
+def print_summary(converged: bool, iterations: int, x_star: np.ndarray) -> None:
+    """Summary lines after the run."""
+    x_star_round = np.round(x_star, 3)
+    f_at_round = function(x_star_round)
+    print(f"Converged: {converged}")
+    print(f"iterations: {iterations}")
+    print(f"x* ≈ [{x_star_round[0]:.3f}, {x_star_round[1]:.3f}]")
+    print(f"F(x*) @ rounded x*: [{f_at_round[0]:.3f}, {f_at_round[1]:.3f}]\n")
+
+
+def print_history(history) -> None:
+    """Iteration table with aligned columns."""
+    print("iteration |        x1        |        x2        |    abs_error")
+    print("---------------------------------------------------------------")
+    for step in history:
+        x1, x2 = step.current_estimate
+        print(
+            f"{step.iteration:9d} | "
+            f"{x1:14.6f} | "
+            f"{x2:14.6f} | "
+            f"{step.stopping_value:12.6f}"
+        )
+
+
+def main() -> None:
+    # Exercise parameters (must be explicit here; do not hard-code in the method)
+    epsilon = 0.1
+    max_iterations = 3
+    initial_guess = np.array([1.0, 1.0], dtype=float)
+
+    print_header(epsilon=epsilon, max_iterations=max_iterations, initial_guess=initial_guess)
+
+    result = newton_system(
+        function=function,
+        jacobian=jacobian,
+        initial_guess=initial_guess,
+        tolerance=epsilon,
+        max_iterations=max_iterations,
+        stopping_criterion="C",
+    )
+
+    print_summary(
+        converged=result.converged,
+        iterations=result.iterations,
+        x_star=result.approximate_solution,
+    )
+    print_history(result.history)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/problems/problem06b_nonlinear_systems.py
+++ b/scripts/problems/problem06b_nonlinear_systems.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+import numpy as np
+from scripts.methods.nonlinear.newton_systems import newton_system
+
+def function(vector: np.ndarray) -> np.ndarray:
+    """F(x) for Exercise 6(b)."""
+    x1, x2 = vector
+    f1 = x2 - np.cosh(x1 / 2.0)
+    f2 = 9.0 * x1**2 + 25.0 * x2**2 - 225.0
+    return np.array([f1, f2], dtype=float)
+
+
+def jacobian(vector: np.ndarray) -> np.ndarray:
+    """Jacobian J(x) for Exercise 6(b)."""
+    x1, x2 = vector
+    # ∂f1/∂x1 = - (1/2) * sinh(x1/2);  ∂f1/∂x2 = 1
+    # ∂f2/∂x1 = 18*x1;                 ∂f2/∂x2 = 50*x2
+    j11 = -0.5 * np.sinh(x1 / 2.0)
+    j12 = 1.0
+    j21 = 18.0 * x1
+    j22 = 50.0 * x2
+    return np.array([[j11, j12], [j21, j22]], dtype=float)
+
+
+def print_header(epsilon: float, max_iterations: int, initial_guess: np.ndarray) -> None:
+    """Minimal header required by the project."""
+    print("=== Newton method for SEANL (Exercise 6b) ===")
+    print("f1(x1, x2) = x2 - cosh(x1/2)")
+    print("f2(x1, x2) = 9*x1^2 + 25*x2^2 - 225")
+    print(f"Initial guess x(0) = [{initial_guess[0]:.3f}, {initial_guess[1]:.3f}]")
+    print("Stopping: Criterion C (absolute), ε =", f"{epsilon:.3f}")
+    print(f"Max iterations: {max_iterations}")
+    print("Round final x* to 3 decimals; evaluate F at the rounded x*.\n")
+
+
+def print_summary(converged: bool, iterations: int, x_star: np.ndarray) -> None:
+    """Summary lines after the run."""
+    x_star_round = np.round(x_star, 3)
+    f_at_round = function(x_star_round)
+    print(f"Converged: {converged}")
+    print(f"iterations: {iterations}")
+    print(f"x* ≈ [{x_star_round[0]:.3f}, {x_star_round[1]:.3f}]")
+    print(f"F(x*) @ rounded x*: [{f_at_round[0]:.3f}, {f_at_round[1]:.3f}]\n")
+
+
+def print_history(history) -> None:
+    """Iteration table with aligned columns."""
+    print("iteration |        x1        |        x2        |    abs_error")
+    print("---------------------------------------------------------------")
+    for step in history:
+        x1, x2 = step.current_estimate
+        print(
+            f"{step.iteration:9d} | "
+            f"{x1:14.6f} | "
+            f"{x2:14.6f} | "
+            f"{step.stopping_value:12.6f}"
+        )
+
+
+def main() -> None:
+    # Exercise parameters (explicit here; never hard-code in the method).
+    epsilon = 0.1
+    max_iterations = 3
+    initial_guess = np.array([2.5, 2.0], dtype=float)
+
+    print_header(epsilon=epsilon, max_iterations=max_iterations, initial_guess=initial_guess)
+
+    result = newton_system(
+        function=function,
+        jacobian=jacobian,
+        initial_guess=initial_guess,
+        tolerance=epsilon,
+        max_iterations=max_iterations,
+        stopping_criterion="C",
+    )
+
+    print_summary(
+        converged=result.converged,
+        iterations=result.iterations,
+        x_star=result.approximate_solution,
+    )
+    print_history(result.history)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/problems/problem06c_nonlinear_systems.py
+++ b/scripts/problems/problem06c_nonlinear_systems.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+import numpy as np
+from scripts.methods.nonlinear.newton_systems import newton_system
+
+def function(vector: np.ndarray) -> np.ndarray:
+    """F(x) for Exercise 6(c)."""
+    x1, x2, x3 = vector
+    f1 = x1**2 + x2**2 + x3**2 - 1.0
+    f2 = x1**2 + x2**2 - 4.0 * x3
+    f3 = x1**2 - x2 + x3**2
+    return np.array([f1, f2, f3], dtype=float)
+
+
+def jacobian(vector: np.ndarray) -> np.ndarray:
+    """Jacobian J(x) for Exercise 6(c)."""
+    x1, x2, x3 = vector
+    # Row 1: [2*x1,  2*x2, 2*x3]
+    # Row 2: [2*x1,  2*x2,   -4 ]
+    # Row 3: [2*x1,    -1 , 2*x3]
+    return np.array(
+        [
+            [2.0 * x1, 2.0 * x2, 2.0 * x3],
+            [2.0 * x1, 2.0 * x2, -4.0],
+            [2.0 * x1, -1.0, 2.0 * x3],
+        ],
+        dtype=float,
+    )
+
+
+def print_header(epsilon: float, max_iterations: int, initial_guess: np.ndarray) -> None:
+    """Minimal header required by the project."""
+    print("=== Newton method for SEANL (Exercise 6c) ===")
+    print("f1(x) = x1^2 + x2^2 + x3^2 - 1")
+    print("f2(x) = x1^2 + x2^2 - 4*x3")
+    print("f3(x) = x1^2 - x2 + x3^2")
+    print(f"Initial guess x(0) = [{initial_guess[0]:.3f}, {initial_guess[1]:.3f}, {initial_guess[2]:.3f}]")
+    print("Stopping: Criterion C (absolute), ε =", f"{epsilon:.3f}")
+    print(f"Max iterations: {max_iterations}")
+    print("Round final x* to 3 decimals; evaluate F at the rounded x*.\n")
+
+
+def print_summary(converged: bool, iterations: int, x_star: np.ndarray) -> None:
+    """Summary lines after the run."""
+    x_star_round = np.round(x_star, 3)
+    f_at_round = function(x_star_round)
+    print(f"Converged: {converged}")
+    print(f"iterations: {iterations}")
+    print(f"x* ≈ [{x_star_round[0]:.3f}, {x_star_round[1]:.3f}, {x_star_round[2]:.3f}]")
+    print(f"F(x*) @ rounded x*: [{f_at_round[0]:.3f}, {f_at_round[1]:.3f}, {f_at_round[2]:.3f}]\n")
+
+
+def print_history(history) -> None:
+    """Iteration table with aligned columns."""
+    print("iteration |        x1        |        x2        |        x3        |    abs_error")
+    print("-----------------------------------------------------------------------------------")
+    for step in history:
+        x1, x2, x3 = step.current_estimate
+        print(
+            f"{step.iteration:9d} | "
+            f"{x1:14.6f} | "
+            f"{x2:14.6f} | "
+            f"{x3:14.6f} | "
+            f"{step.stopping_value:12.6f}"
+        )
+
+
+def main() -> None:
+    # Exercise parameters (explicit here; never hard-code in the method).
+    epsilon = 0.1
+    max_iterations = 3
+    initial_guess = np.array([0.5, 0.5, 0.5], dtype=float)
+
+    print_header(epsilon=epsilon, max_iterations=max_iterations, initial_guess=initial_guess)
+
+    result = newton_system(
+        function=function,
+        jacobian=jacobian,
+        initial_guess=initial_guess,
+        tolerance=epsilon,
+        max_iterations=max_iterations,
+        stopping_criterion="C",
+    )
+
+    print_summary(
+        converged=result.converged,
+        iterations=result.iterations,
+        x_star=result.approximate_solution,
+    )
+    print_history(result.history)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement problems 6(a), 6(b) and 6(c) using the generic newton_system.Stopping: Criterion C (absolute step), ε=0.1, max 3 iterations. Standard header, summary (x* rounded to 3 decimals) and iteration table. Files: problems/p06a_newton_system.py,
       problems/problem06b_nonlinear_systems.py,
       problems/problem06c_nonlinear_systems.py